### PR TITLE
Fixed Jupyter Notebook

### DIFF
--- a/minDQN.ipynb
+++ b/minDQN.ipynb
@@ -149,7 +149,7 @@
         "\n",
         "        X.append(observation)\n",
         "        Y.append(current_qs)\n",
-        "    model.fit(np.array(X), np.array(Y), batch_size=batch_size, verbose=0, shuffle=True)\n",
+        "    model.fit(np.array(X), np.array(Y), batch_size=batch_size, verbose=0, shuffle=True)\n"
       ],
       "execution_count": null,
       "outputs": []


### PR DESCRIPTION
There is an extra comma in the notebook that gives errors on at least some platforms like on GitHub and on (at least my version of) Jupyter when attempting to open it.